### PR TITLE
docs: add new PR template to github

### DIFF
--- a/.github/Update PULL_REQUEST_TEMPLATE.md
+++ b/.github/Update PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,42 @@
+## PR Checklist
+
+Please check if your PR fulfills the following requirements:
+
+- [ ] The commit message follows conventional commits guidline: https://www.conventionalcommits.org/en/v1.0.0/
+- [ ] Tests for the changes have been added (for bug fixes / features)
+- [ ] Docs have been added / updated (for bug fixes / features)
+
+## PR Type
+
+What kind of change does this PR introduce?
+
+<!-- Please check the one that applies to this PR using "x". -->
+
+```
+[ ] Bugfix
+[ ] Feature
+[ ] Code style update (formatting, local variables)
+[ ] Refactoring (no functional changes, no api changes)
+[ ] Build related changes
+[ ] CI related changes
+[ ] Other... Please describe:
+```
+
+## What is the current behavior?
+
+<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
+
+Issue Number: N/A
+
+## What is the new behavior?
+
+## Does this PR introduce a breaking change?
+
+```
+[ ] Yes
+[ ] No
+```
+
+<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
+
+## Other information


### PR DESCRIPTION
Add PR template to github. 

This template's descriptions and checks will remind developers to follow established development practices for this project.